### PR TITLE
Fix usage of components imported from other files

### DIFF
--- a/packages/vue3/src/build/compiler.js
+++ b/packages/vue3/src/build/compiler.js
@@ -44,8 +44,9 @@ export class VueCompiler extends MultiFileCachingCompiler {
     const hasScoped = descriptor.styles.some((s) => s.scoped)
     const scopeId = hash(filename)
 
+    let scriptResult;
     if (descriptor.script || descriptor.scriptSetup) {
-      const scriptResult = compileScript(descriptor, {
+      scriptResult = compileScript(descriptor, {
         id: scopeId,
         isProd,
       })
@@ -63,6 +64,7 @@ export class VueCompiler extends MultiFileCachingCompiler {
         inMap: descriptor.template.map,
         compilerOptions: {
           scopeId: hasScoped ? `data-v-${scopeId}` : undefined,
+          bindingMetadata: scriptResult ? scriptResult.bindings : undefined,
         },
       })
       if (templateResult.errors && templateResult.errors.length) {


### PR DESCRIPTION
currently, importing a component from another file does not work, eg;

In `main.vue`
```vue
<script setup>
import Other from './other.vue';
</script>
<template>
   <Other />
</template>
```
In `other.vue`
```vue
<template>
   <div>Other Component</div>
</template>
```

After investigation, this is because the template-compiler isn't aware that `Other` is an imported component, so the template code is generating `resolveComponent("Other")` instead of `createVNode(Other)`.

The fix is simply to tell the template compiler about the variables exported from the setup script (via `bindingMetadata`)

Be aware; When testing, meteor will keep caching files even if the compiler is updated, it's useful to run `meteor reset` after changing the compiler so that all files are built with the new version.